### PR TITLE
fig_18: Fix path to qemu-guest

### DIFF
--- a/experiments/fig_18_unikraft-redis-alloc/benchmark.sh
+++ b/experiments/fig_18_unikraft-redis-alloc/benchmark.sh
@@ -38,7 +38,7 @@ do
 
 	for j in {1..5}
 	do
-		taskset -c ${CPU1} qemu-guest \
+		taskset -c ${CPU1} ../../tools/qemu-guest \
 			-i redis.cpio \
 			-k ${IMAGES}/unikraft+${alloc}.kernel \
 			-a "/redis.conf" -m 1024 -p ${CPU2} \


### PR DESCRIPTION
 - Update `fig_18` benchmark script to reference `../../tools/qemu-guest` instead of `qemu-guest`, to fix the script not found error.