### PR TITLE
fig_21: Fix path to qemu-guest

### DIFF
--- a/experiments/fig_21_unikraft-boot-pages/benchmark.sh
+++ b/experiments/fig_21_unikraft-boot-pages/benchmark.sh
@@ -7,7 +7,7 @@ source ../common/set-cpus.sh
 source ../common/qemu.sh
 
 IMAGES=$(pwd)/images
-QEMU_GUEST=qemu-guest
+QEMU_GUEST=../../tools/qemu-guest
 
 benchmark() {
 	taskset -c ${CPU1} ${QEMU_GUEST} \


### PR DESCRIPTION
- Update `QEMU_GUEST` path to use `../../tools/qemu-guest` to fix the script not found error