### PR TITLE
fig_13: Fix path to qemu-guest

### DIFF
--- a/experiments/fig_13_nginx-perf/impl/lupine-qemu-nginx.sh
+++ b/experiments/fig_13_nginx-perf/impl/lupine-qemu-nginx.sh
@@ -36,7 +36,7 @@ for j in {1..5}
 do
 	cp ${IMAGES}/nginx.ext2 ${IMAGES}/nginx.ext2.disposible
 
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-k ${IMAGES}/lupine-qemu.kernel \
 		-d ${IMAGES}/nginx.ext2 \
 		-a "root=/dev/vda rw console=ttyS0 init=/guest_start.sh /trusted/nginx" \

--- a/experiments/fig_13_nginx-perf/impl/microvm-qemu-nginx.sh
+++ b/experiments/fig_13_nginx-perf/impl/microvm-qemu-nginx.sh
@@ -36,7 +36,7 @@ for j in {1..5}
 do
 	cp ${IMAGES}/nginx.ext2 ${IMAGES}/nginx.ext2.disposible
 
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-k ${IMAGES}/generic-qemu.kernel \
 		-d ${IMAGES}/nginx.ext2 \
 		-a "root=/dev/vda rw console=ttyS0 init=/guest_start.sh nginx" \

--- a/experiments/fig_13_nginx-perf/impl/osv-qemu-nginx.sh
+++ b/experiments/fig_13_nginx-perf/impl/osv-qemu-nginx.sh
@@ -17,8 +17,6 @@ touch $LOG
 
 create_bridge $NETIF $BASEIP
 kill_qemu
-
-# run dnsmasq
 dnsmasq_pid=$(run_dhcp $NETIF $BASEIP)
 
 function cleanup {
@@ -42,7 +40,7 @@ do
 		${IMAGES}/osv-qemu.img.disposible \
 		"--rootfs=ramfs /nginx.so -c /nginx/conf/nginx.conf"
 
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-q ${IMAGES}/osv-qemu.img.disposible \
                 -m 1024 -p ${CPU2} \
 		-b ${NETIF} -x
@@ -54,7 +52,7 @@ do
 		tail -n 1 | awk  '{print $3}'`
 
 	# benchmark
-	benchmark_nginx_server $ip $LOG
+	benchmark_nginx_server ${ip} $LOG
 	#curl http://${ip}/index.html --noproxy ${ip} --output -
 
 	# stop server

--- a/experiments/fig_13_nginx-perf/impl/rump-qemu-nginx.sh
+++ b/experiments/fig_13_nginx-perf/impl/rump-qemu-nginx.sh
@@ -49,7 +49,7 @@ do
 		tail -n 1 | awk  '{print $3}'`
 
 	# benchmark
-	benchmark_nginx_server $ip $LOG
+	benchmark_nginx_server ${ip} $LOG
 	#curl http://${ip}/index.html --noproxy ${ip} --output -
 
 	# stop server

--- a/experiments/fig_13_nginx-perf/impl/unikraft-qemu-nginx.sh
+++ b/experiments/fig_13_nginx-perf/impl/unikraft-qemu-nginx.sh
@@ -15,8 +15,6 @@ mkdir -p rawdata results
 
 create_bridge $NETIF $BASEIP
 kill_qemu
-
-# run dnsmasq
 dnsmasq_pid=$(run_dhcp $NETIF $BASEIP)
 
 function cleanup {
@@ -34,7 +32,7 @@ touch $LOG
 
 for j in {1..5}
 do
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-i data/nginx.cpio \
 		-k ${IMAGES}/unikraft+mimalloc.kernel \
 		-a "" -m 1024 -p ${CPU2} \


### PR DESCRIPTION
 - Update `fig_13` impl script to reference `../../tools/qemu-guest` instead of `qemu-guest`, to fix the script not found error.