### PR TITLE
Fix fig12: Resolve Redis build URL and tool paths 

### DIFF
--- a/experiments/fig_12_redis-perf/genimages.sh
+++ b/experiments/fig_12_redis-perf/genimages.sh
@@ -84,6 +84,8 @@ docker run --rm --privileged --name=$CONTAINER \
 			--cpuset-cpus="${CPU1}-${CPU4}" \
 			-v $(pwd)/data:/data-imported \
 			-dt hlefeuvre/osv
+docker exec -it $CONTAINER sed -i -e "s/antirez\/redis/redis\/redis/g" \
+		   /root/osv/apps/redis-memonly/GET
 docker exec -it $CONTAINER cp /data-imported/redis.conf \
 		   /root/osv/apps/redis-memonly/redis.conf
 docker exec -it $CONTAINER sed -i -e "s/always-show-logo/#always-show-logo/" \

--- a/experiments/fig_12_redis-perf/impl/lupine-fc-redis.sh
+++ b/experiments/fig_12_redis-perf/impl/lupine-fc-redis.sh
@@ -32,7 +32,7 @@ for j in {1..5}
 do
 	cp ${IMAGES}/redis.ext2 ${IMAGES}/redis.ext2.disposible
 
-	taskset -c 6,7 firectl --firecracker-binary=./.firecracker \
+	taskset -c 6,7 ../../tools/firectl --firecracker-binary=./.firecracker \
                 --kernel ${IMAGES}/lupine-fc.kernel \
                 --tap-device=tap100/AA:FC:00:00:00:01 \
                 --root-drive=${IMAGES}/redis.ext2.disposible \

--- a/experiments/fig_12_redis-perf/impl/lupine-qemu-redis.sh
+++ b/experiments/fig_12_redis-perf/impl/lupine-qemu-redis.sh
@@ -35,7 +35,7 @@ for j in {1..5}
 do
 	cp ${IMAGES}/redis.ext2 ${IMAGES}/redis.ext2.disposible
 
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-k ${IMAGES}/lupine-qemu.kernel \
 		-d ${IMAGES}/redis.ext2.disposible \
 		-a "root=/dev/vda rw console=ttyS0 init=/guest_start.sh /trusted/redis-server" \

--- a/experiments/fig_12_redis-perf/impl/microvm-fc-redis.sh
+++ b/experiments/fig_12_redis-perf/impl/microvm-fc-redis.sh
@@ -31,7 +31,7 @@ for j in {1..5}
 do
 	cp ${IMAGES}/redis.ext2 /tmp/redis.ext2.disposible
 
-	taskset -c ${CPU1},${CPU2} firectl --firecracker-binary=./.firecracker \
+	taskset -c ${CPU1},${CPU2} ../../tools/firectl --firecracker-binary=./.firecracker \
                 --kernel ${IMAGES}/generic-fc.kernel \
                 --tap-device=tap100/AA:FC:00:00:00:01 \
                 --root-drive=/tmp/redis.ext2.disposible \

--- a/experiments/fig_12_redis-perf/impl/microvm-qemu-redis.sh
+++ b/experiments/fig_12_redis-perf/impl/microvm-qemu-redis.sh
@@ -35,7 +35,7 @@ for j in {1..5}
 do
 	cp ${IMAGES}/redis.ext2 ${IMAGES}/redis.ext2.disposible
 
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-k ${IMAGES}/generic-qemu.kernel \
 		-d ${IMAGES}/redis.ext2.disposible \
 		-a "root=/dev/vda rw console=ttyS0 init=/guest_start.sh redis-server" \

--- a/experiments/fig_12_redis-perf/impl/osv-qemu-redis.sh
+++ b/experiments/fig_12_redis-perf/impl/osv-qemu-redis.sh
@@ -43,7 +43,7 @@ do
 		${IMAGES}/osv-qemu.img.disposible \
 		"--rootfs=zfs /redis-server redis.conf"
 
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-q ${IMAGES}/osv-qemu.img.disposible \
                 -m 1024 -p ${CPU2} \
 		-b ${NETIF} -x

--- a/experiments/fig_12_redis-perf/impl/unikraft-qemu-redis.sh
+++ b/experiments/fig_12_redis-perf/impl/unikraft-qemu-redis.sh
@@ -35,7 +35,7 @@ touch $LOG
 
 for j in {1..5}
 do
-	taskset -c ${CPU1} qemu-guest \
+	taskset -c ${CPU1} ../../tools/qemu-guest \
 		-i data/redis.cpio \
 		-k ${IMAGES}/unikraft+mimalloc.kernel \
 		-a "/redis.conf" -m 1024 -p ${CPU2} \


### PR DESCRIPTION
Fixes the OSv Redis performance benchmarking setup ( fig_12_redis-perf ) by repairing a broken source download link and correcting helper script paths.
